### PR TITLE
Reassigned the body type "QuadrupedPokemonWithHoovesAndTail"

### DIFF
--- a/Data/DataPokemon.csv
+++ b/Data/DataPokemon.csv
@@ -75,8 +75,8 @@ DexNumber,Name,DefName,Type1,Type2,HP,Attack,Defense,SpAttack,SpDefense,Speed,Si
 74,Geodude,Geodude,Rock,Ground,40,80,100,30,30,20,0.4,1,20,0,50,0,0.5,1,31,0,1,25,0,0,0,0,1,4,12,MediumSlow,255,Mineral,,15,5,10,73,0,0,1,0,0,0,HeadPokemonWithArms
 75,Graveler,Graveler,Rock,Ground,55,95,115,45,45,35,1,1,105,0,50,0,0.5,2,31,0,1,38,0,0,0,0,4,25,30,MediumSlow,120,Mineral,,15,5,10,134,0,0,2,0,0,0,BipedPokemon
 76,Golem,Golem,Rock,Ground,80,120,130,55,65,45,1.4,1,300,0,50,0,0.5,3,31,1,0,0,0,0,0,0,7,38,45,MediumSlow,45,Mineral,,15,5,10,177,0,0,3,0,0,0,BipedPokemon
-77,Ponyta,Ponyta,Fire,,50,85,55,65,65,90,1,1,30,0,50,0,0.5,1,32,0,1,40,0,0,0,0,3,6,18,MediumFast,190,Field,,20,6.7,13.3,152,0,0,0,0,0,1,QuadrupedPokemonWithPaws
-78,Rapidash,Rapidash,Fire,,65,100,70,80,80,105,1.7,1,95,0,50,0,0.5,2,32,1,0,0,0,0,0,0,6,40,45,MediumFast,60,Field,,20,6.7,13.3,192,0,0,0,0,0,2,QuadrupedPokemonWithPaws
+77,Ponyta,Ponyta,Fire,,50,85,55,65,65,90,1,1,30,0,50,0,0.5,1,32,0,1,40,0,0,0,0,3,6,18,MediumFast,190,Field,,20,6.7,13.3,152,0,0,0,0,0,1,QuadrupedPokemonWithHoovesAndTail
+78,Rapidash,Rapidash,Fire,,65,100,70,80,80,105,1.7,1,95,0,50,0,0.5,2,32,1,0,0,0,0,0,0,6,40,45,MediumFast,60,Field,,20,6.7,13.3,192,0,0,0,0,0,2,QuadrupedPokemonWithHoovesAndTail
 79,Slowpoke,Slowpoke,Water,Psychic,90,65,65,40,40,15,1.2,1,36,0,50,0,0.5,1,33,0,1,37,0,0,0,0,2,6,18,MediumFast,190,Monster,Water1,20,6.7,13.3,99,1,0,0,0,0,0,QuadrupedPokemonWithPaws
 80,Slowbro,Slowbro,Water,Psychic,95,75,110,100,80,30,1.6,1,78.5,0,50,0,0.5,2,33,1,0,0,0,0,0,0,6,37,42,MediumFast,75,Monster,Water1,20,6.7,13.3,164,0,0,2,0,0,0,BipedPokemonWithTail
 81,Magnemite,Magnemite,Electric,Steel,25,35,70,95,55,45,0.3,1,6,0,50,1,-1,1,34,0,1,30,0,0,0,0,2,6,16,MediumFast,190,Mineral,,20,6.7,13.3,89,0,0,0,1,0,0,HeadPokemonWithArms
@@ -126,7 +126,7 @@ DexNumber,Name,DefName,Type1,Type2,HP,Attack,Defense,SpAttack,SpDefense,Speed,Si
 125,Electabuzz,Electabuzz,Electric,,65,83,57,95,85,105,1.1,1,30,0,50,0,0.25,2,60,0,1,43,0,0,0,0,4,18,30,MediumFast,45,HumanLike,,25,8.3,16.7,156,0,0,0,0,0,2,BipedPokemonWithTail
 126,Magmar,Magmar,Fire,,65,95,57,100,85,93,1.3,1,44.5,0,50,0,0.25,2,61,0,1,43,0,0,0,0,4,18,30,MediumFast,45,HumanLike,,25,8.3,16.7,167,0,0,0,2,0,0,BipedPokemonWithTail
 127,Pinsir,Pinsir,Bug,,65,125,100,55,70,85,1.5,1,55,0,50,0,0.5,1,62,1,0,0,0,0,0,0,5,24,34,Slow,45,Bug,,25,8.3,16.7,200,0,2,0,0,0,0,BipedPokemon
-128,Tauros,Tauros,Normal,,75,100,95,40,70,110,1.4,1,88.4,0,50,0,0,1,63,1,0,0,0,0,0,0,4,24,34,Slow,45,Field,,20,6.7,13.3,211,0,1,0,0,0,1,QuadrupedPokemonWithPaws
+128,Tauros,Tauros,Normal,,75,100,95,40,70,110,1.4,1,88.4,0,50,0,0,1,63,1,0,0,0,0,0,0,4,24,34,Slow,45,Field,,20,6.7,13.3,211,0,1,0,0,0,1,QuadrupedPokemonWithHoovesAndTail
 129,Magikarp,Magikarp,Water,,20,10,55,15,20,80,0.9,1,10,0,50,0,0.5,1,64,0,1,20,0,0,0,0,1,3,8,Slow,255,Water2,Dragon,5,1.7,3.3,20,0,0,0,0,0,1,FishPokemonWithPectoralCaudalDorsalFins
 130,Gyarados,Gyarados,Water,Flying,95,125,79,60,100,81,6.5,1,235,0,50,0,0.5,2,64,1,0,0,0,0,0,0,7,30,40,Slow,45,Water2,Dragon,5,1.7,3.3,214,0,2,0,0,0,0,SnakePokemon
 131,Lapras,Lapras,Water,Ice,130,85,80,85,95,60,2.5,1,220,0,50,0,0.5,1,65,1,0,0,0,0,0,0,6,30,40,Slow,45,Monster,Water1,40,13.3,26.7,219,2,0,0,0,0,0,FishPokemonWithPectoralCaudalDorsalFins
@@ -201,7 +201,7 @@ DexNumber,Name,DefName,Type1,Type2,HP,Attack,Defense,SpAttack,SpDefense,Speed,Si
 200,Misdreavus,Misdreavus,Ghost,,60,60,60,85,85,85,0.7,1,1,0,35,0,0.5,1,99,0,1,32,0,0,0,0,3,6,12,Fast,45,Amorphous,,25,8.3,16.7,147,0,0,0,0,1,0,HeadPokemon
 201,Unown,Unown,Psychic,,48,72,48,72,48,48,0.5,1,5,0,50,1,-1,1,100,1,0,0,0,0,0,1,4,25,25,MediumFast,225,Undiscovered,,40,13.3,26.7,61,0,1,0,1,0,0,HeadPokemon
 202,Wobbuffet,Wobbuffet,Psychic,,190,33,58,33,58,33,1.3,1,28.5,1,50,0,0.5,2,101,1,0,0,0,0,0,0,4,18,26,MediumFast,45,Amorphous,,20,6.7,13.3,177,2,0,0,0,0,0,HeadPokemonWithBody
-203,Girafarig,Girafarig,Normal,Psychic,70,80,65,90,65,85,1.5,1,41.5,0,50,0,0.5,1,102,1,0,0,0,0,0,0,4,18,26,MediumFast,60,Field,,20,6.7,13.3,149,0,0,0,2,0,0,QuadrupedPokemonWithPaws
+203,Girafarig,Girafarig,Normal,Psychic,70,80,65,90,65,85,1.5,1,41.5,0,50,0,0.5,1,102,1,0,0,0,0,0,0,4,18,26,MediumFast,60,Field,,20,6.7,13.3,149,0,0,0,2,0,0,QuadrupedPokemonWithHoovesAndTail
 204,Pineco,Pineco,Bug,,50,65,90,35,35,15,0.6,1,7.2,0,50,0,0.5,1,103,0,1,31,0,0,0,0,2,6,12,MediumFast,190,Bug,,20,6.7,13.3,60,0,0,1,0,0,0,HeadPokemon
 205,Forretress,Forretress,Bug,Steel,75,90,140,60,60,40,1.2,1,125.8,0,50,0,0.5,2,103,1,0,0,0,0,0,0,6,32,38,MediumFast,75,Bug,,20,6.7,13.3,118,0,0,2,0,0,0,HeadPokemon
 206,Dunsparce,Dunsparce,Normal,,100,70,70,65,65,45,1.5,1,14,0,50,0,0.5,1,104,1,0,0,0,0,0,0,4,16,24,MediumFast,190,Field,,20,6.7,13.3,125,1,0,0,0,0,0,SnakePokemon
@@ -232,7 +232,7 @@ DexNumber,Name,DefName,Type1,Type2,HP,Attack,Defense,SpAttack,SpDefense,Speed,Si
 231,Phanpy,Phanpy,Ground,,90,60,60,40,40,40,0.5,1,33.5,0,50,0,0.5,1,120,0,1,25,0,0,0,0,1,5,12,MediumFast,120,Field,,20,6.7,13.3,124,1,0,0,0,0,0,QuadrupedPokemonWithPaws
 232,Donphan,Donphan,Ground,,90,120,120,60,60,50,1.1,1,120,0,50,0,0.5,2,120,1,0,0,0,0,0,0,5,28,34,MediumFast,60,Field,,20,6.7,13.3,189,0,1,1,0,0,0,QuadrupedPokemonWithPaws
 233,Porygon2,Porygon2_,Normal,,85,80,90,105,95,60,0.6,1,32.5,0,50,1,-1,2,68,0,0,0,0,0,0,1,7,20,20,MediumFast,45,Mineral,,20,6.7,13.3,180,0,0,0,2,0,0,HeadPokemonWithLegs
-234,Stantler,Stantler,Normal,,73,95,62,85,65,85,1.4,1,71.2,0,50,0,0.5,1,121,1,0,0,0,0,0,0,4,18,26,Slow,45,Field,,20,6.7,13.3,165,0,1,0,0,0,0,QuadrupedPokemonWithPaws
+234,Stantler,Stantler,Normal,,73,95,62,85,65,85,1.4,1,71.2,0,50,0,0.5,1,121,1,0,0,0,0,0,0,4,18,26,Slow,45,Field,,20,6.7,13.3,165,0,1,0,0,0,0,QuadrupedPokemonWithHoovesAndTail
 235,Smeargle,Smeargle,Normal,,55,20,35,20,45,75,1.2,1,58,0,50,0,0.5,1,122,1,0,0,0,0,0,0,5,16,24,Fast,45,Field,,20,6.7,13.3,106,0,0,0,0,0,1,BipedPokemonWithTail
 236,Tyrogue,Tyrogue,Fighting,,35,35,35,35,35,35,0.7,1,21,0,50,0,0,1,47,0,1,20,1,0,0,0,3,2,5,MediumFast,75,Undiscovered,,25,8.3,16.7,91,0,1,0,0,0,0,BipedPokemon
 237,Hitmontop,Hitmontop,Fighting,,50,95,95,35,110,70,1.4,1,48,0,50,0,0,2,47,1,0,0,0,0,0,0,5,30,36,MediumFast,45,HumanLike,,25,8.3,16.7,138,0,0,0,0,2,0,BipedPokemonWithTail
@@ -321,7 +321,7 @@ DexNumber,Name,DefName,Type1,Type2,HP,Attack,Defense,SpAttack,SpDefense,Speed,Si
 320,Wailmer,Wailmer,Water,,130,70,35,70,35,60,2,1,130,0,50,0,0.5,1,162,0,1,40,0,0,0,0,4,14,20,Fluctuating,125,Field,Water2,40,13.3,26.7,137,1,0,0,0,0,0,FishPokemonWithPectoralCaudalDorsalFins
 321,Wailord,Wailord,Water,,170,90,45,90,45,60,14.5,2,398,0,50,0,0.5,2,162,1,0,0,0,0,0,0,8,40,46,Fluctuating,60,Field,Water2,40,13.3,26.7,206,2,0,0,0,0,0,FishPokemonWithPectoralCaudalDorsalFins
 322,Numel,Numel,Fire,Ground,60,60,40,65,45,35,0.7,1,24,0,50,0,0.5,1,163,0,1,33,0,0,0,0,2,6,14,MediumFast,255,Field,,20,6.7,13.3,88,0,0,0,1,0,0,QuadrupedPokemonWithPaws
-323,Camerupt,Camerupt,Fire,Ground,70,100,70,105,75,40,1.9,1,220,0,50,0,0.5,2,163,1,0,0,0,0,0,0,6,36,42,MediumFast,150,Field,,20,6.7,13.3,175,0,1,0,1,0,0,QuadrupedPokemonWithPaws
+323,Camerupt,Camerupt,Fire,Ground,70,100,70,105,75,40,1.9,1,220,0,50,0,0.5,2,163,1,0,0,0,0,0,0,6,36,42,MediumFast,150,Field,,20,6.7,13.3,175,0,1,0,1,0,0,QuadrupedPokemonWithHoovesAndTail
 324,Torkoal,Torkoal,Fire,,70,85,140,85,70,20,0.5,1,80.4,0,50,0,0.5,1,164,1,0,0,0,0,0,0,4,24,30,MediumFast,90,Field,,20,6.7,13.3,161,0,0,2,0,0,0,QuadrupedPokemonWithPaws
 325,Spoink,Spoink,Psychic,,60,25,35,70,80,60,0.7,1,30.6,0,50,0,0.5,1,165,0,1,32,0,0,0,0,1,4,12,Fast,255,Field,,20,6.7,13.3,89,0,0,0,0,1,0,HeadPokemonWithArms
 326,Grumpig,Grumpig,Psychic,,80,45,65,90,110,80,0.9,1,71.5,0,50,0,0.5,2,165,1,0,0,0,0,0,0,5,32,38,Fast,60,Field,,20,6.7,13.3,164,0,0,0,0,2,0,BipedPokemonWithTail
@@ -491,4 +491,4 @@ DexNumber,Name,DefName,Type1,Type2,HP,Attack,Defense,SpAttack,SpDefense,Speed,Si
 490,Manaphy,Manaphy,Water,,100,100,100,100,100,100,0.3,1,1.4,0,50,1,-1,1,245,1,0,0,0,0,1,0,10,30,30,Slow,3,Water1,Fairy,40,13.3,26.7,215,3,0,0,0,0,0,BipedPokemon
 491,Darkrai,Darkrai,Dark,,70,90,90,135,90,125,1.5,1,50.5,0,0,1,-1,1,246,1,0,0,0,0,1,0,10,50,50,Slow,3,Undiscovered,,120,40,80,210,0,0,0,2,0,1,BipedPokemon
 492,Shaymin,Shaymin,Grass,,100,100,100,100,100,100,0.2,1,2.1,0,100,1,-1,1,247,1,0,0,0,0,1,0,10,30,30,MediumSlow,45,Undiscovered,,120,40,80,64,3,0,0,0,0,0,QuadrupedPokemonWithPaws
-493,Arceus,Arceus,Normal,,120,120,120,120,120,120,3.2,2,320,0,0,1,-1,1,248,1,0,0,0,0,1,0,10,90,90,Slow,3,Undiscovered,,120,40,80,255,3,0,0,0,0,0,QuadrupedPokemonWithPaws
+493,Arceus,Arceus,Normal,,120,120,120,120,120,120,3.2,2,320,0,0,1,-1,1,248,1,0,0,0,0,1,0,10,90,90,Slow,3,Undiscovered,,120,40,80,255,3,0,0,0,0,0,QuadrupedPokemonWithHoovesAndTail


### PR DESCRIPTION
The following pokémon had been assigned the body type "QuadrupedPokemonWithHoovesAndTail" (the new body type has been pull requested in the other repo):

* Ponyta, Rapidash, Tauros, Girafarig, Stantler, Camerupt, Arceus.